### PR TITLE
Align to AVM Spec and use CDT for CMK

### DIFF
--- a/avm/res/net-app/net-app-account/README.md
+++ b/avm/res/net-app/net-app-account/README.md
@@ -17,9 +17,9 @@ This module deploys an Azure NetApp File.
 | :-- | :-- |
 | `Microsoft.Authorization/locks` | [2020-05-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2020-05-01/locks) |
 | `Microsoft.Authorization/roleAssignments` | [2022-04-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments) |
-| `Microsoft.NetApp/netAppAccounts` | [2022-11-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.NetApp/2022-11-01/netAppAccounts) |
-| `Microsoft.NetApp/netAppAccounts/capacityPools` | [2022-11-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.NetApp/2022-11-01/netAppAccounts/capacityPools) |
-| `Microsoft.NetApp/netAppAccounts/capacityPools/volumes` | [2022-11-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.NetApp/2022-11-01/netAppAccounts/capacityPools/volumes) |
+| `Microsoft.NetApp/netAppAccounts` | [2023-11-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.NetApp/netAppAccounts) |
+| `Microsoft.NetApp/netAppAccounts/capacityPools` | [2023-11-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.NetApp/netAppAccounts/capacityPools) |
+| `Microsoft.NetApp/netAppAccounts/capacityPools/volumes` | [2023-11-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.NetApp/netAppAccounts/capacityPools/volumes) |
 
 ## Usage examples
 
@@ -645,26 +645,22 @@ module netAppAccount 'br/public:avm/res/net-app/net-app-account:<version>' = {
 
 | Parameter | Type | Description |
 | :-- | :-- | :-- |
-| [`aesEncryption`](#parameter-aesEncryption) | bool | Enable AES encryption on the SMB Server. |
+| [`aesEncryption`](#parameter-aesencryption) | bool | Enable AES encryption on the SMB Server. |
 | [`capacityPools`](#parameter-capacitypools) | array | Capacity pools to create. |
+| [`customerManagedKey`](#parameter-customermanagedkey) | object | The customer managed key definition. |
 | [`dnsServers`](#parameter-dnsservers) | string | Required if domainName is specified. Comma separated list of DNS server IP addresses (IPv4 only) required for the Active Directory (AD) domain join and SMB authentication operations to succeed. |
 | [`domainJoinOU`](#parameter-domainjoinou) | string | Used only if domainName is specified. LDAP Path for the Organization Unit (OU) where SMB Server machine accounts will be created (i.e. 'OU=SecondLevel,OU=FirstLevel'). |
 | [`domainJoinPassword`](#parameter-domainjoinpassword) | securestring | Required if domainName is specified. Password of the user specified in domainJoinUser parameter. |
 | [`domainJoinUser`](#parameter-domainjoinuser) | string | Required if domainName is specified. Username of Active Directory domain administrator, with permissions to create SMB server machine account in the AD domain. |
 | [`domainName`](#parameter-domainname) | string | Fully Qualified Active Directory DNS Domain Name (e.g. 'contoso.com'). |
-| [`keyName`](#parameter-keyName) | string | The key name to use for encryption. |
-| [`keySource`](#parameter-keySource) | string | The key source Microsoft.Keyvault for CMK or Microsoft Managed Key (default). |
-| [`keyVaultResourceId`](#parameter-keyVaultResourceId) | string | The keyvault resource Id to use for encryption. |
-| [`keyVaultUri`](#parameter-keyVaultUri) | string | The keyvault URI to use for encryption. |
 | [`enableTelemetry`](#parameter-enabletelemetry) | bool | Enable/Disable usage telemetry for module. |
-| [`ldapSigning`](#parameter-ldapSigning) | bool | Specifies whether or not the LDAP traffic needs to be signed. |
+| [`ldapSigning`](#parameter-ldapsigning) | bool | Specifies whether or not the LDAP traffic needs to be signed. |
 | [`location`](#parameter-location) | string | Location for all resources. |
 | [`lock`](#parameter-lock) | object | The lock settings of the service. |
 | [`managedIdentities`](#parameter-managedidentities) | object | The managed identity definition for this resource. |
 | [`roleAssignments`](#parameter-roleassignments) | array | Array of role assignments to create. |
 | [`smbServerNamePrefix`](#parameter-smbservernameprefix) | string | Required if domainName is specified. NetBIOS name of the SMB server. A computer account with this prefix will be registered in the AD and used to mount volumes. |
 | [`tags`](#parameter-tags) | object | Tags for all resources. |
-`
 
 ### Parameter: `name`
 
@@ -688,6 +684,55 @@ Capacity pools to create.
 - Required: No
 - Type: array
 - Default: `[]`
+
+### Parameter: `customerManagedKey`
+
+The customer managed key definition.
+
+- Required: No
+- Type: object
+
+**Required parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`keyName`](#parameter-customermanagedkeykeyname) | string | The name of the customer managed key to use for encryption. |
+| [`keyVaultResourceId`](#parameter-customermanagedkeykeyvaultresourceid) | string | The resource ID of a key vault to reference a customer managed key for encryption from. |
+
+**Optional parameters**
+
+| Parameter | Type | Description |
+| :-- | :-- | :-- |
+| [`keyVersion`](#parameter-customermanagedkeykeyversion) | string | The version of the customer managed key to reference for encryption. If not provided, using 'latest'. |
+| [`userAssignedIdentityResourceId`](#parameter-customermanagedkeyuserassignedidentityresourceid) | string | User assigned identity to use when fetching the customer managed key. Required if no system assigned identity is available for use. |
+
+### Parameter: `customerManagedKey.keyName`
+
+The name of the customer managed key to use for encryption.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `customerManagedKey.keyVaultResourceId`
+
+The resource ID of a key vault to reference a customer managed key for encryption from.
+
+- Required: Yes
+- Type: string
+
+### Parameter: `customerManagedKey.keyVersion`
+
+The version of the customer managed key to reference for encryption. If not provided, using 'latest'.
+
+- Required: No
+- Type: string
+
+### Parameter: `customerManagedKey.userAssignedIdentityResourceId`
+
+User assigned identity to use when fetching the customer managed key. Required if no system assigned identity is available for use.
+
+- Required: No
+- Type: string
 
 ### Parameter: `dnsServers`
 
@@ -736,38 +781,6 @@ Enable/Disable usage telemetry for module.
 - Required: No
 - Type: bool
 - Default: `True`
-
-### Parameter: `keyName`
-
-The key name to use for encryption
-
-- Required: No
-- Type: string
-- Default: `''`
-
-### Parameter: `keySource`
-
-The key source Microsoft.Keyvault for CMK or Microsoft Managed Key (default)
-
-- Required: No
-- Type: string
-- Default: `''`
-
-### Parameter: `keyVaultResourceId`
-
-The keyvault resource Id to use for encryption
-
-- Required: No
-- Type: string
-- Default: `''`
-
-### Parameter: `keyVaultUri`
-
-The keyvault URI to use for encryption
-
-- Required: No
-- Type: string
-- Default: `''`
 
 ### Parameter: `ldapSigning`
 

--- a/avm/res/net-app/net-app-account/capacity-pool/README.md
+++ b/avm/res/net-app/net-app-account/capacity-pool/README.md
@@ -15,8 +15,8 @@ This module deploys an Azure NetApp Files Capacity Pool.
 | Resource Type | API Version |
 | :-- | :-- |
 | `Microsoft.Authorization/roleAssignments` | [2022-04-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments) |
-| `Microsoft.NetApp/netAppAccounts/capacityPools` | [2022-11-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.NetApp/2022-11-01/netAppAccounts/capacityPools) |
-| `Microsoft.NetApp/netAppAccounts/capacityPools/volumes` | [2022-11-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.NetApp/2022-11-01/netAppAccounts/capacityPools/volumes) |
+| `Microsoft.NetApp/netAppAccounts/capacityPools` | [2023-11-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.NetApp/netAppAccounts/capacityPools) |
+| `Microsoft.NetApp/netAppAccounts/capacityPools/volumes` | [2023-11-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.NetApp/netAppAccounts/capacityPools/volumes) |
 
 ## Parameters
 

--- a/avm/res/net-app/net-app-account/capacity-pool/main.bicep
+++ b/avm/res/net-app/net-app-account/capacity-pool/main.bicep
@@ -63,11 +63,11 @@ var builtInRoleNames = {
   )
 }
 
-resource netAppAccount 'Microsoft.NetApp/netAppAccounts@2022-11-01' existing = {
+resource netAppAccount 'Microsoft.NetApp/netAppAccounts@2023-11-01' existing = {
   name: netAppAccountName
 }
 
-resource capacityPool 'Microsoft.NetApp/netAppAccounts/capacityPools@2022-11-01' = {
+resource capacityPool 'Microsoft.NetApp/netAppAccounts/capacityPools@2023-11-01' = {
   name: name
   parent: netAppAccount
   location: location

--- a/avm/res/net-app/net-app-account/capacity-pool/main.json
+++ b/avm/res/net-app/net-app-account/capacity-pool/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.26.54.24096",
-      "templateHash": "9491401922190427460"
+      "version": "0.27.1.19265",
+      "templateHash": "16622075120254910820"
     },
     "name": "Azure NetApp Files Capacity Pools",
     "description": "This module deploys an Azure NetApp Files Capacity Pool.",
@@ -182,12 +182,12 @@
     "netAppAccount": {
       "existing": true,
       "type": "Microsoft.NetApp/netAppAccounts",
-      "apiVersion": "2022-11-01",
+      "apiVersion": "2023-11-01",
       "name": "[parameters('netAppAccountName')]"
     },
     "capacityPool": {
       "type": "Microsoft.NetApp/netAppAccounts/capacityPools",
-      "apiVersion": "2022-11-01",
+      "apiVersion": "2023-11-01",
       "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('name'))]",
       "location": "[parameters('location')]",
       "tags": "[parameters('tags')]",
@@ -273,8 +273,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.26.54.24096",
-              "templateHash": "9587584861242006945"
+              "version": "0.27.1.19265",
+              "templateHash": "8316026534353601275"
             },
             "name": "Azure NetApp Files Capacity Pool Volumes",
             "description": "This module deploys an Azure NetApp Files Capacity Pool Volume.",
@@ -440,7 +440,7 @@
             "netAppAccount::capacityPool": {
               "existing": true,
               "type": "Microsoft.NetApp/netAppAccounts/capacityPools",
-              "apiVersion": "2022-11-01",
+              "apiVersion": "2023-11-01",
               "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('capacityPoolName'))]",
               "dependsOn": [
                 "netAppAccount"
@@ -449,12 +449,12 @@
             "netAppAccount": {
               "existing": true,
               "type": "Microsoft.NetApp/netAppAccounts",
-              "apiVersion": "2022-11-01",
+              "apiVersion": "2023-11-01",
               "name": "[parameters('netAppAccountName')]"
             },
             "volume": {
               "type": "Microsoft.NetApp/netAppAccounts/capacityPools/volumes",
-              "apiVersion": "2022-11-01",
+              "apiVersion": "2023-11-01",
               "name": "[format('{0}/{1}/{2}', parameters('netAppAccountName'), parameters('capacityPoolName'), parameters('name'))]",
               "location": "[parameters('location')]",
               "properties": {
@@ -519,7 +519,7 @@
               "metadata": {
                 "description": "The location the resource was deployed into."
               },
-              "value": "[reference('volume', '2022-11-01', 'full').location]"
+              "value": "[reference('volume', '2023-11-01', 'full').location]"
             }
           }
         }
@@ -557,7 +557,7 @@
       "metadata": {
         "description": "The location the resource was deployed into."
       },
-      "value": "[reference('capacityPool', '2022-11-01', 'full').location]"
+      "value": "[reference('capacityPool', '2023-11-01', 'full').location]"
     }
   }
 }

--- a/avm/res/net-app/net-app-account/capacity-pool/volume/README.md
+++ b/avm/res/net-app/net-app-account/capacity-pool/volume/README.md
@@ -15,7 +15,7 @@ This module deploys an Azure NetApp Files Capacity Pool Volume.
 | Resource Type | API Version |
 | :-- | :-- |
 | `Microsoft.Authorization/roleAssignments` | [2022-04-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments) |
-| `Microsoft.NetApp/netAppAccounts/capacityPools/volumes` | [2022-11-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.NetApp/2022-11-01/netAppAccounts/capacityPools/volumes) |
+| `Microsoft.NetApp/netAppAccounts/capacityPools/volumes` | [2023-11-01](https://learn.microsoft.com/en-us/azure/templates/Microsoft.NetApp/netAppAccounts/capacityPools/volumes) |
 
 ## Parameters
 

--- a/avm/res/net-app/net-app-account/capacity-pool/volume/main.bicep
+++ b/avm/res/net-app/net-app-account/capacity-pool/volume/main.bicep
@@ -55,15 +55,15 @@ var builtInRoleNames = {
   )
 }
 
-resource netAppAccount 'Microsoft.NetApp/netAppAccounts@2022-11-01' existing = {
+resource netAppAccount 'Microsoft.NetApp/netAppAccounts@2023-11-01' existing = {
   name: netAppAccountName
 
-  resource capacityPool 'capacityPools@2022-11-01' existing = {
+  resource capacityPool 'capacityPools@2023-11-01' existing = {
     name: capacityPoolName
   }
 }
 
-resource volume 'Microsoft.NetApp/netAppAccounts/capacityPools/volumes@2022-11-01' = {
+resource volume 'Microsoft.NetApp/netAppAccounts/capacityPools/volumes@2023-11-01' = {
   name: name
   parent: netAppAccount::capacityPool
   location: location

--- a/avm/res/net-app/net-app-account/capacity-pool/volume/main.json
+++ b/avm/res/net-app/net-app-account/capacity-pool/volume/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.26.54.24096",
-      "templateHash": "9587584861242006945"
+      "version": "0.27.1.19265",
+      "templateHash": "8316026534353601275"
     },
     "name": "Azure NetApp Files Capacity Pool Volumes",
     "description": "This module deploys an Azure NetApp Files Capacity Pool Volume.",
@@ -172,7 +172,7 @@
     "netAppAccount::capacityPool": {
       "existing": true,
       "type": "Microsoft.NetApp/netAppAccounts/capacityPools",
-      "apiVersion": "2022-11-01",
+      "apiVersion": "2023-11-01",
       "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('capacityPoolName'))]",
       "dependsOn": [
         "netAppAccount"
@@ -181,12 +181,12 @@
     "netAppAccount": {
       "existing": true,
       "type": "Microsoft.NetApp/netAppAccounts",
-      "apiVersion": "2022-11-01",
+      "apiVersion": "2023-11-01",
       "name": "[parameters('netAppAccountName')]"
     },
     "volume": {
       "type": "Microsoft.NetApp/netAppAccounts/capacityPools/volumes",
-      "apiVersion": "2022-11-01",
+      "apiVersion": "2023-11-01",
       "name": "[format('{0}/{1}/{2}', parameters('netAppAccountName'), parameters('capacityPoolName'), parameters('name'))]",
       "location": "[parameters('location')]",
       "properties": {
@@ -251,7 +251,7 @@
       "metadata": {
         "description": "The location the resource was deployed into."
       },
-      "value": "[reference('volume', '2022-11-01', 'full').location]"
+      "value": "[reference('volume', '2023-11-01', 'full').location]"
     }
   }
 }

--- a/avm/res/net-app/net-app-account/main.bicep
+++ b/avm/res/net-app/net-app-account/main.bicep
@@ -8,6 +8,9 @@ param name string
 @description('Optional. Enable AES encryption on the SMB Server.')
 param aesEncryption bool = false
 
+@description('Optional. The customer managed key definition.')
+param customerManagedKey customerManagedKeyType
+
 @description('Optional. Fully Qualified Active Directory DNS Domain Name (e.g. \'contoso.com\').')
 param domainName string = ''
 
@@ -133,6 +136,26 @@ resource avmTelemetry 'Microsoft.Resources/deployments@2023-07-01' = if (enableT
   }
 }
 
+resource cMKKeyVault 'Microsoft.KeyVault/vaults@2023-02-01' existing = if (!empty(customerManagedKey.?keyVaultResourceId)) {
+  name: last(split((customerManagedKey.?keyVaultResourceId ?? 'dummyVault'), '/'))
+  scope: resourceGroup(
+    split((customerManagedKey.?keyVaultResourceId ?? '//'), '/')[2],
+    split((customerManagedKey.?keyVaultResourceId ?? '////'), '/')[4]
+  )
+
+  resource cMKKey 'keys@2023-02-01' existing = if (!empty(customerManagedKey.?keyVaultResourceId) && !empty(customerManagedKey.?keyName)) {
+    name: customerManagedKey.?keyName ?? 'dummyKey'
+  }
+}
+
+resource cMKUserAssignedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' existing = if (!empty(customerManagedKey.?userAssignedIdentityResourceId)) {
+  name: last(split(customerManagedKey.?userAssignedIdentityResourceId ?? 'dummyMsi', '/'))
+  scope: resourceGroup(
+    split((customerManagedKey.?userAssignedIdentityResourceId ?? '//'), '/')[2],
+    split((customerManagedKey.?userAssignedIdentityResourceId ?? '////'), '/')[4]
+  )
+}
+
 resource netAppAccount 'Microsoft.NetApp/netAppAccounts@2022-11-01' = {
   name: name
   tags: tags
@@ -245,3 +268,17 @@ type roleAssignmentType = {
   @description('Optional. The Resource Id of the delegated managed identity resource.')
   delegatedManagedIdentityResourceId: string?
 }[]?
+
+type customerManagedKeyType = {
+  @description('Required. The resource ID of a key vault to reference a customer managed key for encryption from.')
+  keyVaultResourceId: string
+
+  @description('Required. The name of the customer managed key to use for encryption.')
+  keyName: string
+
+  @description('Optional. The version of the customer managed key to reference for encryption. If not provided, using \'latest\'.')
+  keyVersion: string?
+
+  @description('Optional. User assigned identity to use when fetching the customer managed key. Required if no system assigned identity is available for use.')
+  userAssignedIdentityResourceId: string?
+}?

--- a/avm/res/net-app/net-app-account/main.json
+++ b/avm/res/net-app/net-app-account/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.26.54.24096",
-      "templateHash": "5838174533550571700"
+      "version": "0.27.1.19265",
+      "templateHash": "17614166962197031000"
     },
     "name": "Azure NetApp Files",
     "description": "This module deploys an Azure NetApp File.",
@@ -118,6 +118,38 @@
         }
       },
       "nullable": true
+    },
+    "customerManagedKeyType": {
+      "type": "object",
+      "properties": {
+        "keyVaultResourceId": {
+          "type": "string",
+          "metadata": {
+            "description": "Required. The resource ID of a key vault to reference a customer managed key for encryption from."
+          }
+        },
+        "keyName": {
+          "type": "string",
+          "metadata": {
+            "description": "Required. The name of the customer managed key to use for encryption."
+          }
+        },
+        "keyVersion": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. The version of the customer managed key to reference for encryption. If not provided, using 'latest'."
+          }
+        },
+        "userAssignedIdentityResourceId": {
+          "type": "string",
+          "nullable": true,
+          "metadata": {
+            "description": "Optional. User assigned identity to use when fetching the customer managed key. Required if no system assigned identity is available for use."
+          }
+        }
+      },
+      "nullable": true
     }
   },
   "parameters": {
@@ -132,6 +164,12 @@
       "defaultValue": false,
       "metadata": {
         "description": "Optional. Enable AES encryption on the SMB Server."
+      }
+    },
+    "customerManagedKey": {
+      "$ref": "#/definitions/customerManagedKeyType",
+      "metadata": {
+        "description": "Optional. The customer managed key definition."
       }
     },
     "domainName": {
@@ -195,34 +233,6 @@
         "description": "Optional. Array of role assignments to create."
       }
     },
-    "keyName": {
-      "type": "string",
-      "defaultValue": "",
-      "metadata": {
-        "description": "Optional. The name of the key to use for encryption."
-      }
-    },
-    "keySource": {
-      "type": "string",
-      "defaultValue": "",
-      "metadata": {
-        "description": "Optional. The name of the key to use for encryption."
-      }
-    },
-    "keyVaultResourceId": {
-      "type": "string",
-      "defaultValue": "",
-      "metadata": {
-        "description": "Optional. The resource ID of the key vault to use for encryption."
-      }
-    },
-    "keyVaultUri": {
-      "type": "string",
-      "defaultValue": "",
-      "metadata": {
-        "description": "Optional. The URI of the key vault to use for encryption."
-      }
-    },
     "ldapSigning": {
       "type": "bool",
       "defaultValue": false,
@@ -261,21 +271,14 @@
   "variables": {
     "activeDirectoryConnectionProperties": [
       {
+        "aesEncryption": "[if(not(empty(parameters('domainName'))), parameters('aesEncryption'), false())]",
         "username": "[if(not(empty(parameters('domainName'))), parameters('domainJoinUser'), null())]",
         "password": "[if(not(empty(parameters('domainName'))), parameters('domainJoinPassword'), null())]",
         "domain": "[if(not(empty(parameters('domainName'))), parameters('domainName'), null())]",
         "dns": "[if(not(empty(parameters('domainName'))), parameters('dnsServers'), null())]",
+        "ldapSigning": "[if(not(empty(parameters('domainName'))), parameters('ldapSigning'), false())]",
         "smbServerName": "[if(not(empty(parameters('domainName'))), parameters('smbServerNamePrefix'), null())]",
-        "organizationalUnit": "[if(not(empty(parameters('domainJoinOU'))), parameters('domainJoinOU'), null())]",
-        "aesEncryption": "[if(not(empty(parameters('aesEncryption))), parameters('aesEncryption), false)]",
-        "ldapSigning": "[if(not(empty(parameters('ldapSigning))), parameters('ldapSigning), false)]"
-      }
-    ],
-    "encryptionProperties": [
-      {
-        "keyName": "[if(not(empty(parameters('keyName'))), parameters('keyName'), null())]",
-        "keyVaultResourceId": "[if(not(empty(parameters('keyVaultResourceId'))), parameters('keyVaultResourceId'), null())]",
-        "keyVaultUri": "[if(not(empty(parameters('keyVaultUri'))), parameters('keyVaultUri'), null())]"
+        "organizationalUnit": "[if(not(empty(parameters('domainJoinOU'))), parameters('domainJoinOU'), null())]"
       }
     ],
     "formattedUserAssignedIdentities": "[reduce(map(coalesce(tryGet(parameters('managedIdentities'), 'userAssignedResourceIds'), createArray()), lambda('id', createObject(format('{0}', lambdaVariables('id')), createObject()))), createObject(), lambda('cur', 'next', union(lambdaVariables('cur'), lambdaVariables('next'))))]",
@@ -289,6 +292,18 @@
     }
   },
   "resources": {
+    "cMKKeyVault::cMKKey": {
+      "condition": "[and(not(empty(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'))), and(not(empty(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'))), not(empty(tryGet(parameters('customerManagedKey'), 'keyName')))))]",
+      "existing": true,
+      "type": "Microsoft.KeyVault/vaults/keys",
+      "apiVersion": "2023-02-01",
+      "subscriptionId": "[split(coalesce(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '//'), '/')[2]]",
+      "resourceGroup": "[split(coalesce(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '////'), '/')[4]]",
+      "name": "[format('{0}/{1}', last(split(coalesce(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), 'dummyVault'), '/')), coalesce(tryGet(parameters('customerManagedKey'), 'keyName'), 'dummyKey'))]",
+      "dependsOn": [
+        "cMKKeyVault"
+      ]
+    },
     "avmTelemetry": {
       "condition": "[parameters('enableTelemetry')]",
       "type": "Microsoft.Resources/deployments",
@@ -309,16 +324,39 @@
         }
       }
     },
+    "cMKKeyVault": {
+      "condition": "[not(empty(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId')))]",
+      "existing": true,
+      "type": "Microsoft.KeyVault/vaults",
+      "apiVersion": "2023-02-01",
+      "subscriptionId": "[split(coalesce(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '//'), '/')[2]]",
+      "resourceGroup": "[split(coalesce(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '////'), '/')[4]]",
+      "name": "[last(split(coalesce(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), 'dummyVault'), '/'))]"
+    },
+    "cMKUserAssignedIdentity": {
+      "condition": "[not(empty(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId')))]",
+      "existing": true,
+      "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
+      "apiVersion": "2023-01-31",
+      "subscriptionId": "[split(coalesce(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), '//'), '/')[2]]",
+      "resourceGroup": "[split(coalesce(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), '////'), '/')[4]]",
+      "name": "[last(split(coalesce(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), 'dummyMsi'), '/'))]"
+    },
     "netAppAccount": {
       "type": "Microsoft.NetApp/netAppAccounts",
-      "apiVersion": "2022-11-01",
+      "apiVersion": "2023-11-01",
       "name": "[parameters('name')]",
       "tags": "[parameters('tags')]",
       "identity": "[variables('identity')]",
       "location": "[parameters('location')]",
       "properties": {
-        "activeDirectories": "[if(not(empty(parameters('domainName'))), variables('activeDirectoryConnectionProperties'), null())]"
-      }
+        "activeDirectories": "[if(not(empty(parameters('domainName'))), variables('activeDirectoryConnectionProperties'), null())]",
+        "encryption": "[if(not(empty(parameters('customerManagedKey'))), createObject('identity', if(not(empty(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'))), createObject('userAssignedIdentity', extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(coalesce(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), '//'), '/')[2], split(coalesce(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), '////'), '/')[4]), 'Microsoft.ManagedIdentity/userAssignedIdentities', last(split(coalesce(tryGet(parameters('customerManagedKey'), 'userAssignedIdentityResourceId'), 'dummyMsi'), '/')))), null()), 'keySource', 'Microsoft.KeyVault', 'keyVaultProperties', createObject('keyName', parameters('customerManagedKey').keyName, 'keyVaultResourceId', extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', split(coalesce(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '//'), '/')[2], split(coalesce(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), '////'), '/')[4]), 'Microsoft.KeyVault/vaults', last(split(coalesce(tryGet(parameters('customerManagedKey'), 'keyVaultResourceId'), 'dummyVault'), '/'))), 'keyVaultUri', reference('cMKKeyVault').vaultUri)), null())]"
+      },
+      "dependsOn": [
+        "cMKKeyVault",
+        "cMKUserAssignedIdentity"
+      ]
     },
     "netAppAccount_lock": {
       "condition": "[and(not(empty(coalesce(parameters('lock'), createObject()))), not(equals(tryGet(parameters('lock'), 'kind'), 'None')))]",
@@ -399,8 +437,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.26.54.24096",
-              "templateHash": "9491401922190427460"
+              "version": "0.27.1.19265",
+              "templateHash": "16622075120254910820"
             },
             "name": "Azure NetApp Files Capacity Pools",
             "description": "This module deploys an Azure NetApp Files Capacity Pool.",
@@ -576,12 +614,12 @@
             "netAppAccount": {
               "existing": true,
               "type": "Microsoft.NetApp/netAppAccounts",
-              "apiVersion": "2022-11-01",
+              "apiVersion": "2023-11-01",
               "name": "[parameters('netAppAccountName')]"
             },
             "capacityPool": {
               "type": "Microsoft.NetApp/netAppAccounts/capacityPools",
-              "apiVersion": "2022-11-01",
+              "apiVersion": "2023-11-01",
               "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('name'))]",
               "location": "[parameters('location')]",
               "tags": "[parameters('tags')]",
@@ -667,8 +705,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.26.54.24096",
-                      "templateHash": "9587584861242006945"
+                      "version": "0.27.1.19265",
+                      "templateHash": "8316026534353601275"
                     },
                     "name": "Azure NetApp Files Capacity Pool Volumes",
                     "description": "This module deploys an Azure NetApp Files Capacity Pool Volume.",
@@ -834,7 +872,7 @@
                     "netAppAccount::capacityPool": {
                       "existing": true,
                       "type": "Microsoft.NetApp/netAppAccounts/capacityPools",
-                      "apiVersion": "2022-11-01",
+                      "apiVersion": "2023-11-01",
                       "name": "[format('{0}/{1}', parameters('netAppAccountName'), parameters('capacityPoolName'))]",
                       "dependsOn": [
                         "netAppAccount"
@@ -843,12 +881,12 @@
                     "netAppAccount": {
                       "existing": true,
                       "type": "Microsoft.NetApp/netAppAccounts",
-                      "apiVersion": "2022-11-01",
+                      "apiVersion": "2023-11-01",
                       "name": "[parameters('netAppAccountName')]"
                     },
                     "volume": {
                       "type": "Microsoft.NetApp/netAppAccounts/capacityPools/volumes",
-                      "apiVersion": "2022-11-01",
+                      "apiVersion": "2023-11-01",
                       "name": "[format('{0}/{1}/{2}', parameters('netAppAccountName'), parameters('capacityPoolName'), parameters('name'))]",
                       "location": "[parameters('location')]",
                       "properties": {
@@ -913,7 +951,7 @@
                       "metadata": {
                         "description": "The location the resource was deployed into."
                       },
-                      "value": "[reference('volume', '2022-11-01', 'full').location]"
+                      "value": "[reference('volume', '2023-11-01', 'full').location]"
                     }
                   }
                 }
@@ -951,7 +989,7 @@
               "metadata": {
                 "description": "The location the resource was deployed into."
               },
-              "value": "[reference('capacityPool', '2022-11-01', 'full').location]"
+              "value": "[reference('capacityPool', '2023-11-01', 'full').location]"
             }
           }
         }
@@ -988,7 +1026,7 @@
       "metadata": {
         "description": "The location the resource was deployed into."
       },
-      "value": "[reference('netAppAccount', '2022-11-01', 'full').location]"
+      "value": "[reference('netAppAccount', '2023-11-01', 'full').location]"
     }
   }
 }


### PR DESCRIPTION
## Description

This PR should help resolve the comment https://github.com/Azure/bicep-registry-modules/pull/2089/files#r1619233077 in the PR https://github.com/Azure/bicep-registry-modules/pull/2089

### Copilot summary

This pull request updates the Azure NetApp Files (ANF) module in the `avm/res/net-app/net-app-account` directory. The most significant changes include updating the API version for ANF to `2023-11-01`, removing encryption properties that are no longer needed, and adding a new `customerManagedKey` parameter. 

Here are the top five most important changes:

API Version Updates:
* `avm/res/net-app/net-app-account/README.md`, `avm/res/net-app/net-app-account/capacity-pool/README.md`, `avm/res/net-app/net-app-account/capacity-pool/volume/README.md`: Updated the API version for `Microsoft.NetApp/netAppAccounts`, `Microsoft.NetApp/netAppAccounts/capacityPools`, and `Microsoft.NetApp/netAppAccounts/capacityPools/volumes` from `2022-11-01` to `2023-11-01`. [[1]](diffhunk://#diff-927c0e5b66a44fb3b7c183443bcee3050d43de9a6851484c581f96734de0f267L20-R22) [[2]](diffhunk://#diff-72a30a7271875e38f637800c512cf42516f509f79c7b69ec92990d10a51fbf5aL18-R19) [[3]](diffhunk://#diff-188338d9b8beaf3b47be97e69b2d7bfeaecc56c5c1329a135275d54fd414cdb8L18-R18)

Parameter Changes:
* [`avm/res/net-app/net-app-account/README.md`](diffhunk://#diff-927c0e5b66a44fb3b7c183443bcee3050d43de9a6851484c581f96734de0f267L648-L667): Added a new `customerManagedKey` parameter and removed encryption-related parameters such as `keyName`, `keySource`, `keyVaultResourceId`, and `keyVaultUri`. [[1]](diffhunk://#diff-927c0e5b66a44fb3b7c183443bcee3050d43de9a6851484c581f96734de0f267L648-L667) [[2]](diffhunk://#diff-927c0e5b66a44fb3b7c183443bcee3050d43de9a6851484c581f96734de0f267L692-R783)
* [`avm/res/net-app/net-app-account/main.bicep`](diffhunk://#diff-687940ecf218a15da3d6d7d4ac938a4e258dbd5df460a8ff55cd96064ff9ff16R11-R13): Added a new `customerManagedKey` parameter and removed encryption-related parameters. [[1]](diffhunk://#diff-687940ecf218a15da3d6d7d4ac938a4e258dbd5df460a8ff55cd96064ff9ff16R11-R13) [[2]](diffhunk://#diff-687940ecf218a15da3d6d7d4ac938a4e258dbd5df460a8ff55cd96064ff9ff16L39-L50)

Codebase Simplification:
* [`avm/res/net-app/net-app-account/main.bicep`](diffhunk://#diff-687940ecf218a15da3d6d7d4ac938a4e258dbd5df460a8ff55cd96064ff9ff16L79-L90): Removed the `encryptionProperties` variable as it's no longer needed due to the removal of encryption-related parameters.

Resource Type Updates:
* `avm/res/net-app/net-app-account/capacity-pool/main.bicep`, `avm/res/net-app/net-app-account/capacity-pool/volume/main.bicep`: Updated the resource type `Microsoft.NetApp/netAppAccounts/capacityPools` and `Microsoft.NetApp/netAppAccounts/capacityPools/volumes` to use the new API version `2023-11-01`. [[1]](diffhunk://#diff-82558e18f940bba22356a9c92284050ca4390c54158165d4bcecd75d941cd81fL66-R70) [[2]](diffhunk://#diff-3e187d8578f951cca967abce6cc775e19c24b377af6feaa5a278bcb303d42e1aL58-R66)
